### PR TITLE
Change logo icon color in dark mode

### DIFF
--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -44,7 +44,7 @@ const Navbar = () => {
     >
       <div className='navbar-brand'>
         <Link className='navbar-item' id='brand' to='/'>
-          <Terminal color='blue' />
+          <Terminal color={ isDarkMode ? '#FFCC4D' : 'blue'} />
           &emsp;WEBDEVSCOM
         </Link>
 


### PR DESCRIPTION
Previously 'blue' color, the logo icon was changed to '#FFCC4D' color when theme is toggled from light to dark mode.

With the help of ternary operator, the current theme is checked. If in case the theme is dark, then the logo icon color was is to '#FFCC4D', else the logo icon color is set to 'blue'.